### PR TITLE
Add setup directives to use 2to3 with python3 and add trove categories to...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,15 +15,32 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import couleur
 from setuptools import setup
+import sys
+
+extra = {}
+if sys.version_info >= (3,0):
+    u = str
+    extra.update( use_2to3 = True )
+else:
+    u = lambda s: unicode(s, 'utf8')
+
 
 setup(name='couleur',
-    version=couleur.__version__,
+    version=0.3,
     description='ANSI terminal tool for python, colored shell and other ' \
         'handy fancy features',
-    author=u'Gabriel Falcão',
+    author=u('Gabriel Falcão'),
     author_email='gabriel@nacaolivre.org',
     url='http://github.com/gabrielfalcao/couleur',
     py_modules=['couleur'],
+    classifiers = [
+        'Development Status :: 5 - Production/Stable',
+        'License :: OSI Approved :: Apache Software License',
+        "Operating System :: POSIX",
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
+    ],
+    **extra
 )


### PR DESCRIPTION
...make it python3 compatible on pypi

Hi,
I tested couleur on python3 after using 2to3 to convert the code and it works great.

I have updated setup.py so that setuptools will automatically use 2to3 when called with python3. This way it can be published on pypi and installed with easy_install/pip on both python2 and python3.

I would be great if you could merge this commit and publish a new release on pypi accordingly.

Thanks!
