### PR TITLE
Custom markers

### DIFF
--- a/test_file_filter.py
+++ b/test_file_filter.py
@@ -36,7 +36,7 @@ def test_output_black_foreground_alternative():
     "file-like filter output: black foreground with alternative markers"
 
     io = StringIO()
-    couleur.proxy(io, '<', '>').enable()
+    couleur.proxy(io).enable('<', '>')
     io.write("<black>Hello Black!\n")
     assert_equals('\033[30mHello Black!\n', io.getvalue())
     couleur.proxy(io).disable()
@@ -62,7 +62,7 @@ def test_output_black_on_white_foreground_alternative():
     "file-like filter output: black foreground on white background with alternative markers"
 
     io = StringIO()
-    couleur.proxy(io, '<', '>').enable()
+    couleur.proxy(io).enable('<', '>')
     io.write("<black><on:white>Hello Black!\n")
     assert_equals('\033[30;47mHello Black!\n', io.getvalue())
     couleur.proxy(io).disable()
@@ -88,7 +88,7 @@ def test_output_green_foreground_alternative():
     "file-like filter output: green foreground with alternative markers"
 
     io = StringIO()
-    couleur.proxy(io, '<', '>').enable()
+    couleur.proxy(io).enable('<', '>')
     io.write("<green>Hello Green!\n")
     assert_equals('\033[32mHello Green!\n', io.getvalue())
     couleur.proxy(io).disable()
@@ -114,7 +114,7 @@ def test_output_green_and_red_on_white_foreground_alternative():
     "file-like filter output: green foreground and white on red background with alternative markers"
 
     io = StringIO()
-    couleur.proxy(io, '<', '>').enable()
+    couleur.proxy(io).enable('<', '>')
     io.write("<green>Hello <white><on:red>Italy!\n")
     assert_equals('\033[32mHello \033[37;41mItaly!\n', io.getvalue())
     couleur.proxy(io).disable()
@@ -140,7 +140,7 @@ def test_output_bold_green_on_bold_white_alternative():
     "file-like filter output: bold green on white with alternative markers"
 
     io = StringIO()
-    couleur.proxy(io, '<', '>').enable()
+    couleur.proxy(io).enable('<', '>')
     io.write("<bold><green><on:white>Hello\n")
     assert_equals('\033[1;32;47mHello\n', io.getvalue())
     couleur.proxy(io).disable()
@@ -171,7 +171,7 @@ def test_ignoring_colors_alternative():
     "file-like filter output: ignoring output with alternative markers"
 
     io = StringIO()
-    couleur.proxy(io, '<', '>').enable()
+    couleur.proxy(io).enable('<', '>')
     couleur.proxy(io).ignore()
     io.write("<bold><green><on:white>Hello\n")
     assert_equals('Hello\n', io.getvalue())
@@ -195,7 +195,7 @@ def test_supress_up_when_ignoring_colors_alternative():
     "file-like filter output: supress #{up} when ignoring colors with alternative markers"
 
     io = StringIO()
-    couleur.proxy(io, '<', '>').enable()
+    couleur.proxy(io).enable('<', '>')
     couleur.proxy(io).ignore()
     io.write("This is visible<up>but this is invisible\n")
     assert_equals('This is visible', io.getvalue())
@@ -216,7 +216,7 @@ def test_supress_up_when_ignoring_colors_as_many_times_needed_alternative():
     "file-like filter output: supress #{up} as many times as needed with alternative markers"
 
     io = StringIO()
-    couleur.proxy(io, '<', '>').enable()
+    couleur.proxy(io).enable('<', '>')
     couleur.proxy(io).ignore()
     io.write("This is visible<up><up><up><up>\n" \
         " Line one supressed\n" \

--- a/test_stderr_filter.py
+++ b/test_stderr_filter.py
@@ -48,7 +48,7 @@ def test_output_black_foreground():
 def test_output_black_foreground_alternative():
     "STDERR filter output: black foreground with alternative markers"
 
-    couleur.proxy(sys.stderr, '<', '>').enable()
+    couleur.proxy(sys.stderr).enable('<', '>')
     sys.stderr.write("<black>Hello Black!\n")
     assert_stderr('\033[30mHello Black!\n')
     couleur.proxy(sys.stderr).disable()
@@ -70,7 +70,7 @@ def test_output_black_on_white_foreground():
 def test_output_black_on_white_foreground_alternative():
     "STDERR filter output: black foreground on white background with alternative markers"
 
-    couleur.proxy(sys.stderr, '<', '>').enable()
+    couleur.proxy(sys.stderr).enable('<', '>')
     sys.stderr.write("<black><on:white>Hello Black!\n")
     assert_stderr('\033[30;47mHello Black!\n')
     couleur.proxy(sys.stderr).disable()
@@ -92,7 +92,7 @@ def test_output_green_foreground():
 def test_output_green_foreground_alternative():
     "STDERR filter output: green foreground with alternative markers"
 
-    couleur.proxy(sys.stderr, '<', '>').enable()
+    couleur.proxy(sys.stderr).enable('<', '>')
     sys.stderr.write("<green>Hello Green!\n")
     assert_stderr('\033[32mHello Green!\n')
     couleur.proxy(sys.stderr).disable()
@@ -114,7 +114,7 @@ def test_output_green_and_red_on_white_foreground():
 def test_output_green_and_red_on_white_foreground_alternative():
     "STDERR filter output: green foreground and white on red background with alternative markers"
 
-    couleur.proxy(sys.stderr, '<', '>').enable()
+    couleur.proxy(sys.stderr).enable('<', '>')
     sys.stderr.write("<green>Hello <white><on:red>Italy!\n")
     assert_stderr('\033[32mHello \033[37;41mItaly!\n')
     couleur.proxy(sys.stderr).disable()
@@ -140,11 +140,11 @@ def test_errput_stderr_ignoring_errput():
 def test_errput_stderr_ignoring_errput_alternative():
     "STDERR filter errput: ignoring output with alternative markers"
 
-    couleur.proxy(sys.stderr, '<', '>').enable()
+    couleur.proxy(sys.stderr).enable('<', '>')
     couleur.proxy(sys.stderr).ignore()
     sys.stderr.write("<green>Hello <white><on:blue>World!<reset>\n")
     assert_stderr('Hello World!\n')
-    couleur.proxy(sys.stderr, '<', '>').enable()
+    couleur.proxy(sys.stderr).enable('<', '>')
     sys.stderr.write("<green>Hi There!\n")
     assert_stderr('\033[32mHi There!\n')
     couleur.proxy(sys.stderr).disable()
@@ -164,7 +164,7 @@ def test_integration_with_stderr_alternative():
     "STDERR filter integration with alternative markers"
 
     sys.stderr = sys.__stderr__
-    couleur.proxy(sys.stderr, '<', '>').enable()
+    couleur.proxy(sys.stderr).enable('<', '>')
     assert sys.stderr is not sys.__stderr__
     couleur.proxy(sys.stderr).disable()
     assert sys.stderr is sys.__stderr__

--- a/test_stdout_filter.py
+++ b/test_stdout_filter.py
@@ -48,7 +48,7 @@ def test_output_black_foreground():
 def test_output_black_foreground_alternative():
     "STDOUT filter output: black foreground with alternative markers"
 
-    couleur.proxy(sys.stdout, '<', '>').enable()
+    couleur.proxy(sys.stdout).enable('<', '>')
     print "<black>Hello Black!<reset>"
     assert_stdout('\033[30mHello Black!\033[0m\n')
     couleur.proxy(sys.stdout).disable()
@@ -70,7 +70,7 @@ def test_output_black_on_white_foreground():
 def test_output_black_on_white_foreground_alternative():
     "STDOUT filter output: black foreground on white background"
 
-    couleur.proxy(sys.stdout, '<', '>').enable()
+    couleur.proxy(sys.stdout).enable('<', '>')
     print "<black><on:white>Hello Black!<reset>"
     assert_stdout('\033[30;47mHello Black!\033[0m\n')
     couleur.proxy(sys.stdout).disable()
@@ -92,7 +92,7 @@ def test_output_green_foreground():
 def test_output_green_foreground_alternative():
     "STDOUT filter output: green foreground"
 
-    couleur.proxy(sys.stdout, '<', '>').enable()
+    couleur.proxy(sys.stdout).enable('<', '>')
     print "<green>Hello Green!<reset>"
     assert_stdout('\033[32mHello Green!\033[0m\n')
     couleur.proxy(sys.stdout).disable()
@@ -114,7 +114,7 @@ def test_output_green_and_red_on_white_foreground():
 def test_output_green_and_red_on_white_foreground_alternative():
     "STDOUT filter output: green foreground and white on red background"
 
-    couleur.proxy(sys.stdout, '<', '>').enable()
+    couleur.proxy(sys.stdout).enable('<', '>')
     print "<green>Hello <white><on:red>Italy!<reset>"
     assert_stdout('\033[32mHello \033[37;41mItaly!\033[0m\n')
     couleur.proxy(sys.stdout).disable()
@@ -140,11 +140,11 @@ def test_output_stdout_ignoring_output():
 def test_output_stdout_ignoring_output_alternative():
     "STDOUT filter output: green foreground and white on red background"
 
-    couleur.proxy(sys.stdout, '<', '>').enable()
+    couleur.proxy(sys.stdout).enable('<', '>')
     couleur.proxy(sys.stdout).ignore()
     print "<green>Hello <white><on:blue>World!<reset>"
     assert_stdout('Hello World!\n')
-    couleur.proxy(sys.stdout, '<', '>').enable()
+    couleur.proxy(sys.stdout).enable('<', '>')
     print "<green>Hi There!"
     assert_stdout('\033[32mHi There!\n')
     couleur.proxy(sys.stdout).disable()
@@ -164,7 +164,7 @@ def test_integration_with_stdout_alternative():
     "STDOUT filter integration"
 
     sys.stdout = sys.__stdout__
-    couleur.proxy(sys.stdout, '<', '>').enable()
+    couleur.proxy(sys.stdout).enable('<', '>')
     assert sys.stdout is not sys.__stdout__
     couleur.proxy(sys.stdout).disable()
     assert sys.stdout is sys.__stdout__


### PR DESCRIPTION
Hi,
I added support for different markers in couleur strings.

The current markers are problematic with the format function that uses {} for it's string interpolation, and this function is the only one supported by python3.

I added the necessary tests and they all pass (both old and new).

I hope you could merge this, since this is almost unuseable on python3, but it also helps with python2.

Thanks.
